### PR TITLE
HLS fallback using FFmpeg

### DIFF
--- a/showroom/core.py
+++ b/showroom/core.py
@@ -233,8 +233,7 @@ class Downloader(object):
         hls recording fails awfully. find out why
         For the failure detection to work properly, must ffmpeg be compiled with librtmp? (yes)
     """
-    # TODO: reset this to RTMP once testing is finished. Allow it to be changed via config.
-    def __init__(self, room, client: ShowroomClient, settings, default_protocol='hls'):
+    def __init__(self, room, client: ShowroomClient, settings, default_protocol='rtmp'):
         self._room = room
         self._client = client
 

--- a/showroom/settings.py
+++ b/showroom/settings.py
@@ -372,7 +372,6 @@ class ShowroomSettings(SettingsDict):
         self._formatting = True
         # TODO: add some properties like e.g. curr_time, curr_date that can be including in formatting specifiers
 
-    # TODO: check that this all works
     @classmethod
     def from_file(cls, path=None):
         new = cls(DEFAULTS)
@@ -393,7 +392,6 @@ class ShowroomSettings(SettingsDict):
 
         new = cls.from_file(path=args.get('config', None))
 
-        # TODO: translate args to settings keys
         args_data = {}
         for key in args:
             if args[key] is not None and key in ARGS_TO_SETTINGS:


### PR DESCRIPTION
Recorder will now automatically switch to HLS if no RTMP streams are found.

HLS recording automatically uses an MPEG-TS container. RTMP can be forced to use TS as well by setting `ffmpeg.container` to `"ts"` in the config file. There might be a commandline option as well.

Concat probably won't handle TS raws properly, I'll deal with that tomorrow.